### PR TITLE
Fix/separate hook from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ yarn add react-simple-typewriter
 import { useTypewriter } from 'react-simple-typewriter'
 
 const CustomSimpleTypewriter = () => {
-  const text = useTypewriter({ words: ['i', 'use', 'hooks!'], loop: true })
+  const text = useTypewriter({
+    words: ['i', 'use', 'hooks!'],
+    loop: true,
+    onLoop: (loopCount) => console.log(`Hook completed loop ${loopCount}`),
+    onDone: () => console.log('Done!')
+  })
+
   return <span>{text}</span>
 }
 ```
@@ -38,7 +44,8 @@ interface TypewriterConfig {
   typeSpeed?: number = 100
   deleteSpeed?: number = 50
   delaySpeed?: number = 1500
-  onLoop?: (loopCount: number) => void = noop
+  onLoop?: (loopCount: number) => void = noop // only called if loop = true
+  onDone?: () => void = noop // only called if loop = false
 }
 ```
 
@@ -80,16 +87,17 @@ export default function App() {
 
 ### Available Props
 
-| Prop          | Type                         | Description                                                                        | Default |
-| ------------- | ---------------------------- | ---------------------------------------------------------------------------------- | :-----: |
-| `loop`        | Boolean                      | Repeat the typing effect (true if present)                                         | `false` |
-| `cursor`      | Boolean                      | Show / Hide cursor (show if present)                                               | `false` |
-| `cursorStyle` | String                       | Change the cursor style                                                            | &#124;  |
-| `typeSpeed`   | Integer                      | Speed in Milliseconds                                                              |  `100`  |
-| `deleteSpeed` | Integer                      | Word deleting speed in Milliseconds                                                |  `50`   |
-| `delaySpeed`  | Integer                      | Delay after the word is written in Milliseconds                                    | `1500`  |
-| `words`       | Array                        | Array of strings holding the words                                                 |    -    |
-| `onLoop`      | (loopCount: Integer) => void | Called when a loop is complete. `loopCount` is the total number of completed loops | `noop`  |
+| Prop          | Type                         | Description                                                                                                    | Default |
+| ------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------- | :-----: |
+| `loop`        | Boolean                      | Repeat the typing effect (true if present)                                                                     | `false` |
+| `cursor`      | Boolean                      | Show / Hide cursor (show if present)                                                                           | `false` |
+| `cursorStyle` | String                       | Change the cursor style                                                                                        | &#124;  |
+| `typeSpeed`   | Integer                      | Speed in Milliseconds                                                                                          |  `100`  |
+| `deleteSpeed` | Integer                      | Word deleting speed in Milliseconds                                                                            |  `50`   |
+| `delaySpeed`  | Integer                      | Delay after the word is written in Milliseconds                                                                | `1500`  |
+| `words`       | Array                        | Array of strings holding the words                                                                             |    -    |
+| `onLoop`      | (loopCount: Integer) => void | Called when a loop is complete. `loopCount` is the total number of completed loops. Only called if loop = true | `noop`  |
+| `onDone`      | () => void                   | Called when typewriter is done. Only called if loop = false                                                    | `noop`  |
 
 ### [Demo](https://react-simple-typewriter.vercel.app/)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ interface TypewriterConfig {
   typeSpeed?: number = 100
   deleteSpeed?: number = 50
   delaySpeed?: number = 1500
+  onLoop?: (loopCount: number) => void = noop
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ export default function App() {
             deleteSpeed={50}
             delaySpeed={1000}
             words={['Eat', 'Sleep', 'Code', 'Repeat!']}
+            onLoop={(loopCount) =>
+              console.log(`Just completed loop ${loopCount}`)
+            }
           />
         </span>
       </h1>
@@ -53,15 +56,16 @@ export default function App() {
 
 ### Available Props
 
-| Prop          | Type    | Description                                     | Default |
-| ------------- | ------- | ----------------------------------------------- | :-----: |
-| `loop`        | Boolean | Repeat the typing effect (true if present)      | `false` |
-| `cursor`      | Boolean | Show / Hide cursor (show if present)            | `false` |
-| `cursorStyle` | String  | Change the cursor style                         | &#124;  |
-| `typeSpeed`   | Integer | Speed in Milliseconds                           |  `100`  |
-| `deleteSpeed` | Integer | Word deleting speed in Milliseconds             |  `50`   |
-| `delaySpeed`  | Integer | Delay after the word is written in Milliseconds | `1500`  |
-| `words`       | Array   | Array of strings holding the words              |    -    |
+| Prop          | Type                         | Description                                                                        | Default |
+| ------------- | ---------------------------- | ---------------------------------------------------------------------------------- | :-----: |
+| `loop`        | Boolean                      | Repeat the typing effect (true if present)                                         | `false` |
+| `cursor`      | Boolean                      | Show / Hide cursor (show if present)                                               | `false` |
+| `cursorStyle` | String                       | Change the cursor style                                                            | &#124;  |
+| `typeSpeed`   | Integer                      | Speed in Milliseconds                                                              |  `100`  |
+| `deleteSpeed` | Integer                      | Word deleting speed in Milliseconds                                                |  `50`   |
+| `delaySpeed`  | Integer                      | Delay after the word is written in Milliseconds                                    | `1500`  |
+| `words`       | Array                        | Array of strings holding the words                                                 |    -    |
+| `onLoop`      | (loopCount: Integer) => void | Called when a loop is complete. `loopCount` is the total number of completed loops | `noop`  |
 
 ### [Demo](https://react-simple-typewriter.vercel.app/)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,30 @@ npm i react-simple-typewriter
 yarn add react-simple-typewriter
 ```
 
-## Usage
+## Usage (Hook)
+
+```jsx
+import { useTypewriter } from 'react-simple-typewriter'
+
+const CustomSimpleTypewriter = () => {
+  const text = useTypewriter({ words: ['i', 'use', 'hooks!'], loop: true })
+  return <span>{text}</span>
+}
+```
+
+### Hook Configuration
+
+```typescript
+interface TypewriterConfig {
+  words: string[]
+  loop?: boolean = false
+  typeSpeed?: number = 100
+  deleteSpeed?: number = 50
+  delaySpeed?: number = 1500
+}
+```
+
+## Usage (Component)
 
 ```jsx
 import React from 'react'

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,7 +4,14 @@ import Typewriter from 'react-smiple-typewriter'
 import 'react-smiple-typewriter/dist/index.css'
 
 const App = () => {
-  return <Typewriter words={['hi', 'world']} cursor loop />
+  return (
+    <Typewriter
+      words={['hi', 'world']}
+      cursor
+      loop
+      onLoop={(loopCount) => console.log(`Just completed loop ${loopCount}`)}
+    />
+  )
 }
 
 export default App

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,7 +7,14 @@ const App = () => {
   return (
     <div style={{ padding: 20 }}>
       <p>The default component</p>
-      <Typewriter words={['hi', 'world']} cursor loop />
+      <Typewriter
+        words={['hi', 'world']}
+        cursor
+        loop
+        onLoop={(loopCount) =>
+          console.log(`Default Component completed loop ${loopCount}`)
+        }
+      />
 
       <hr />
 
@@ -18,7 +25,11 @@ const App = () => {
 }
 
 const CustomSimpleTypewriter = () => {
-  const text = useTypewriter({ words: ['i', 'use', 'hooks!'], loop: true })
+  const text = useTypewriter({
+    words: ['i', 'use', 'hooks!'],
+    loop: true,
+    onLoop: (loopCount) => console.log(`Hook completed loop ${loopCount}`)
+  })
   return <span>{text}</span>
 }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,25 @@
 import React from 'react'
 
-import Typewriter from 'react-smiple-typewriter'
+import Typewriter, { useTypewriter } from 'react-smiple-typewriter'
 import 'react-smiple-typewriter/dist/index.css'
 
 const App = () => {
-  return <Typewriter words={['hi', 'world']} cursor loop />
+  return (
+    <div style={{ padding: 20 }}>
+      <p>The default component</p>
+      <Typewriter words={['hi', 'world']} cursor loop />
+
+      <hr />
+
+      <p>A simple custom typewriter built with the hook!</p>
+      <CustomSimpleTypewriter />
+    </div>
+  )
+}
+
+const CustomSimpleTypewriter = () => {
+  const text = useTypewriter({ words: ['i', 'use', 'hooks!'], loop: true })
+  return <span>{text}</span>
 }
 
 export default App

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,8 +28,10 @@ const CustomSimpleTypewriter = () => {
   const text = useTypewriter({
     words: ['i', 'use', 'hooks!'],
     loop: true,
-    onLoop: (loopCount) => console.log(`Hook completed loop ${loopCount}`)
+    onLoop: (loopCount) => console.log(`Hook completed loop ${loopCount}`), // only called if loop = true
+    onDone: () => console.log('Done!') // only called if loop = false
   })
+
   return <span>{text}</span>
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ interface TypewriterProps {
   typeSpeed?: number
   deleteSpeed?: number
   delaySpeed?: number
+  onLoop?: (loopCount: number) => void
 }
 
 const Typewriter: React.FC<TypewriterProps> = ({
@@ -18,13 +19,30 @@ const Typewriter: React.FC<TypewriterProps> = ({
   cursorStyle = '|',
   typeSpeed = 100,
   delaySpeed = 1500,
-  deleteSpeed = 50
+  deleteSpeed = 50,
+  onLoop = () => {}
 }) => {
   // State
   const [speed, setSpeed] = useState<number>(typeSpeed)
   const [text, setText] = useState<string>('')
   const [isDeleting, setDeleting] = useState<boolean>(false)
   const [counter, setCounter] = useState<number>(0)
+  const [loopCount, setLoopCount] = useState<number>(0)
+
+  const onSetCounter = (prev: number) => {
+    const nextCounter = prev + 1
+
+    // increase loop count, call onLoop callback with completed loop count
+    if (loop && nextCounter % words.length === 0) {
+      setLoopCount((prev) => {
+        const nextLoopCount = prev + 1
+        if (nextLoopCount > 0) onLoop(nextLoopCount)
+        return nextLoopCount
+      })
+    }
+
+    return nextCounter
+  }
 
   const handleTyping = useCallback(() => {
     const index: number = loop ? counter % words.length : counter
@@ -45,7 +63,7 @@ const Typewriter: React.FC<TypewriterProps> = ({
       setSpeed(delaySpeed)
     } else if (isDeleting && text === '') {
       setDeleting(false)
-      setCounter((prev) => prev + 1)
+      setCounter(onSetCounter)
     }
   }, [
     delaySpeed,
@@ -55,7 +73,8 @@ const Typewriter: React.FC<TypewriterProps> = ({
     loop,
     text,
     typeSpeed,
-    words
+    words,
+    loopCount
   ])
 
   // Effect

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,25 +1,28 @@
 import React, { useState, useEffect, useCallback, memo } from 'react'
 import styles from './styles.module.css'
 
-interface TypewriterProps {
+interface TypewriterConfig {
   words: string[]
   loop?: boolean
-  cursor?: boolean
-  cursorStyle?: string
   typeSpeed?: number
   deleteSpeed?: number
   delaySpeed?: number
 }
 
-const Typewriter: React.FC<TypewriterProps> = ({
-  words,
-  loop = false,
-  cursor = false,
-  cursorStyle = '|',
-  typeSpeed = 100,
-  delaySpeed = 1500,
-  deleteSpeed = 50
-}) => {
+interface TypewriterProps extends TypewriterConfig {
+  cursor?: boolean
+  cursorStyle?: string
+}
+
+export const useTypewriter = (config: TypewriterConfig): string => {
+  const {
+    words,
+    typeSpeed = 100,
+    loop = false,
+    deleteSpeed = 50,
+    delaySpeed = 1500
+  } = config
+
   // State
   const [speed, setSpeed] = useState<number>(typeSpeed)
   const [text, setText] = useState<string>('')
@@ -29,6 +32,7 @@ const Typewriter: React.FC<TypewriterProps> = ({
   const handleTyping = useCallback(() => {
     const index: number = loop ? counter % words.length : counter
     const word: string = words[index]
+
     setSpeed(typeSpeed)
 
     if (isDeleting) {
@@ -40,7 +44,11 @@ const Typewriter: React.FC<TypewriterProps> = ({
     }
 
     if (!isDeleting && text === word) {
-      if (!loop && counter >= words.length - 1) return
+      // done!
+      if (!loop && counter >= words.length - 1) {
+        return
+      }
+
       setDeleting(true)
       setSpeed(delaySpeed)
     } else if (isDeleting && text === '') {
@@ -63,6 +71,26 @@ const Typewriter: React.FC<TypewriterProps> = ({
     const timer = setTimeout(() => handleTyping(), speed)
     return () => clearTimeout(timer)
   }, [handleTyping, speed])
+
+  return text
+}
+
+const Typewriter: React.FC<TypewriterProps> = ({
+  words,
+  loop = false,
+  cursor = false,
+  cursorStyle = '|',
+  typeSpeed = 100,
+  delaySpeed = 1500,
+  deleteSpeed = 50
+}) => {
+  const text = useTypewriter({
+    words,
+    loop,
+    typeSpeed,
+    delaySpeed,
+    deleteSpeed
+  })
 
   return (
     <React.Fragment>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback, memo } from 'react'
 import styles from './styles.module.css'
 
+const noop = () => {}
+
 interface TypewriterConfig {
   words: string[]
   loop?: boolean
@@ -8,6 +10,7 @@ interface TypewriterConfig {
   deleteSpeed?: number
   delaySpeed?: number
   onLoop?: (loopCount: number) => void
+  onDone?: () => void
 }
 
 interface TypewriterProps extends TypewriterConfig {
@@ -22,7 +25,8 @@ export const useTypewriter = (config: TypewriterConfig): string => {
     loop = false,
     deleteSpeed = 50,
     delaySpeed = 1500,
-    onLoop = () => {}
+    onLoop = noop,
+    onDone = noop
   } = config
 
   // State
@@ -62,8 +66,8 @@ export const useTypewriter = (config: TypewriterConfig): string => {
     }
 
     if (!isDeleting && text === word) {
-      // done!
       if (!loop && counter >= words.length - 1) {
+        onDone()
         return
       }
 
@@ -102,7 +106,8 @@ const Typewriter: React.FC<TypewriterProps> = ({
   typeSpeed = 100,
   delaySpeed = 1500,
   deleteSpeed = 50,
-  onLoop = () => {}
+  onLoop = noop,
+  onDone = noop
 }) => {
   const text = useTypewriter({
     words,
@@ -110,7 +115,8 @@ const Typewriter: React.FC<TypewriterProps> = ({
     typeSpeed,
     delaySpeed,
     deleteSpeed,
-    onLoop
+    onLoop,
+    onDone
   })
 
   return (


### PR DESCRIPTION
Hey, 

I came across your package and am using it in a project. Thanks for the work!

There were a few use cases I could use so rather than reroll I was hoping to merge this in.

This PR does 3 things. 

1. Extracts the typewriter logic into a `useTypewriter` hook which is exported. The default `<Typewriter />` uses this hook now.
2. Adds `onLoop` callback prop so clients can know what loop the typewriter is on and do logic like fetch from apis
3. Adds `onDone` callback prop

I also edited the `README.md` to account for these changes.